### PR TITLE
Customize top left menu header of admin painel

### DIFF
--- a/admin/src/components/LeftMenu/LeftMenuHeader/Wrapper.js
+++ b/admin/src/components/LeftMenu/LeftMenuHeader/Wrapper.js
@@ -1,0 +1,50 @@
+import styled from 'styled-components';
+import PropTypes from 'prop-types';
+
+import Logo from '../../../assets/images/logo-strapi.png';
+
+const Wrapper = styled.div`
+  background-color: ${props => props.theme.main.colors.black};
+  padding-left: 2rem;
+  height: ${props => props.theme.main.sizes.leftMenu.height};
+
+  .leftMenuHeaderLink {
+    &:hover {
+      text-decoration: none;
+    }
+  }
+
+  .projectName {
+    display: block;
+    width: 100%;
+    height: ${props => props.theme.main.sizes.leftMenu.height};
+    font-size: 2rem;
+    letter-spacing: 0.2rem;
+    color: $white;
+
+    background-image: url(${Logo});
+    background-repeat: no-repeat;
+    background-position: left center;
+    background-size: auto 2.5rem;
+  }
+`;
+
+Wrapper.defaultProps = {
+  theme: {
+    main: {
+      colors: {
+        leftMenu: {},
+      },
+      sizes: {
+        header: {},
+        leftMenu: {},
+      },
+    },
+  },
+};
+
+Wrapper.propTypes = {
+  theme: PropTypes.object,
+};
+
+export default Wrapper;


### PR DESCRIPTION
This PR customizes the background color of the top left menu header on the admin panel 

![image](https://user-images.githubusercontent.com/48022589/99684228-f70cc100-2a5f-11eb-8c69-03e32a7a6e66.png)
