### PR TITLE
Fix locale dropdown on admin panel

### DIFF
--- a/admin/src/components/LeftMenu/LeftMenuHeader/Wrapper.js
+++ b/admin/src/components/LeftMenu/LeftMenuHeader/Wrapper.js
@@ -1,0 +1,50 @@
+import styled from 'styled-components';
+import PropTypes from 'prop-types';
+
+import Logo from '../../../assets/images/logo-strapi.png';
+
+const Wrapper = styled.div`
+  background-color: ${props => props.theme.main.colors.black};
+  padding-left: 2rem;
+  height: ${props => props.theme.main.sizes.leftMenu.height};
+
+  .leftMenuHeaderLink {
+    &:hover {
+      text-decoration: none;
+    }
+  }
+
+  .projectName {
+    display: block;
+    width: 100%;
+    height: ${props => props.theme.main.sizes.leftMenu.height};
+    font-size: 2rem;
+    letter-spacing: 0.2rem;
+    color: $white;
+
+    background-image: url(${Logo});
+    background-repeat: no-repeat;
+    background-position: left center;
+    background-size: auto 2.5rem;
+  }
+`;
+
+Wrapper.defaultProps = {
+  theme: {
+    main: {
+      colors: {
+        leftMenu: {},
+      },
+      sizes: {
+        header: {},
+        leftMenu: {},
+      },
+    },
+  },
+};
+
+Wrapper.propTypes = {
+  theme: PropTypes.object,
+};
+
+export default Wrapper;

--- a/admin/src/components/NavTopRightWrapper/index.js
+++ b/admin/src/components/NavTopRightWrapper/index.js
@@ -1,0 +1,26 @@
+import styled from 'styled-components';
+
+const NavTopRightWrapper = styled.div`
+  position: fixed;
+  top: 0;
+  right: 0;
+  display: flex;
+  z-index: 1050;
+
+  button.localeDropdownContent.btn {
+    padding-left: 2rem;
+
+    span {
+      font-size: 13px;
+      color: ${props => props.theme.main.colors.black} !important; 
+    }
+
+    &:focus,
+    &:active,
+    &:hover {
+      background-color: ${props => props.theme.main.colors.white} !important; 
+    }
+  }
+`;
+
+export default NavTopRightWrapper;

--- a/admin/src/containers/AuthPage/index.js
+++ b/admin/src/containers/AuthPage/index.js
@@ -292,9 +292,6 @@ const AuthPage = ({ hasAdmin }) => {
     <AuthPageWrapper>
       <Padded backgroundColor="#000" bottom size="md">
         <PageTitle title={upperFirst(authType)} />
-        <NavTopRightWrapper>
-          <LocaleToggle isLogged className="localeDropdownMenuNotLogged" />
-        </NavTopRightWrapper>
         <BaselineAlignment top size="78px">
           <Component
             {...rest}


### PR DESCRIPTION
This PR fixes an issue with the background color of the locale dropdown when being shown on the admin panel. 

The customization is done for both the auth pages and admin panel.

![image](https://user-images.githubusercontent.com/48022589/99806810-4e249b80-2b1d-11eb-9c3f-afbacb35a9f7.png)

![image](https://user-images.githubusercontent.com/48022589/99806765-41a04300-2b1d-11eb-92cc-dbb39cba6cca.png)

Unrelated changes:
- Removed the locale dropdown from the auth pages because it was leading to styles conflicts