### PR TITLE
Replace nextActions and previousActions fields

### DIFF
--- a/api/actions-section/models/actions-section.settings.json
+++ b/api/actions-section/models/actions-section.settings.json
@@ -19,10 +19,7 @@
       "type": "text",
       "required": true
     },
-    "nextActions": {
-      "collection": "actions"
-    },
-    "previousActions": {
+    "actions": {
       "collection": "actions"
     },
     "actionButtonText": {


### PR DESCRIPTION
According to https://github.com/LauraBeatris/floripamais/issues/48

All the actions must be stored on the same field and the frontend should show the previous and next ones according to the date 